### PR TITLE
feat: 圈选相关

### DIFF
--- a/app/src/main/java/com/growingio/demo/DemoApplication.kt
+++ b/app/src/main/java/com/growingio/demo/DemoApplication.kt
@@ -17,6 +17,7 @@ import com.growingio.android.sdk.autotrack.GrowingAutotracker
 import com.growingio.android.sdk.track.events.EventFilterInterceptor
 import com.growingio.code.annotation.SourceCode
 import com.growingio.demo.data.settingsDataStore
+import com.growingio.demo.util.GrowingIOManager
 import com.growingio.demo.util.enableStrictMode
 import dagger.hilt.EntryPoint
 import dagger.hilt.EntryPoints
@@ -73,26 +74,53 @@ class GrowingioInitializer : Initializer<Autotracker> {
 
     @SourceCode
     override fun create(context: Context): Autotracker {
-        val growingIOProvider = EntryPoints.get(context, GrowingIOProvider::class.java)
+        //val growingIOProvider = EntryPoints.get(context, GrowingIOProvider::class.java)
+        val growingIOProvider = GrowingIOManager.provideEventFilterInterceptor()
         val agreePolicy = runBlocking { context.settingsDataStore.data.first().agreePolicy }
-        GrowingAutotracker.startWithConfiguration(
-            context,
-            AutotrackConfiguration("0a1b4118dd954ec3bcc69da5138bdb96", "growing.bd71d91eb56f5f53")
-                .setDataSourceId("baffd6fb52b78ca7")
-                .setDataCollectionServerHost("https://napi.growingio.com")
+        val autotrackConfiguration =
+            AutotrackConfiguration(GROWINGIO_PROJECT_ID, GROWINGIO_URL_SCHEME)
+                .setDataSourceId(GROWINGIO_DATASOURCE_ID)
+                .setDataCollectionServerHost(GROWINGIO_SERVER_HOST)
                 .setChannel("demo")
                 .setDebugEnabled(BuildConfig.DEBUG)
                 .setDataCollectionEnabled(agreePolicy)
                 .setCellularDataLimit(10)
                 .setDataUploadInterval(15)
                 .setSessionInterval(30)
-                .setEventFilterInterceptor(growingIOProvider.eventFilterInterceptor())
+                .setEventFilterInterceptor(growingIOProvider)
                 .setIdMappingEnabled(true)
-                .setImpressionScale(0f),
-            // .downgrade()
-        )
+                .setImpressionScale(0f)
+                .downgrade()
+
+        //it's demo logic
+        configWithDataStore(context, autotrackConfiguration)
+        GrowingAutotracker.startWithConfiguration(context, autotrackConfiguration)
 
         return GrowingAutotracker.get()
+    }
+
+    private fun configWithDataStore(context: Context, configuration: AutotrackConfiguration) {
+        runBlocking {
+            val projectId = context.settingsDataStore.data.first().projectId.default(GROWINGIO_PROJECT_ID)
+            val urlScheme = context.settingsDataStore.data.first().urlScheme.default(GROWINGIO_URL_SCHEME)
+            val dataSourceId = context.settingsDataStore.data.first().datasourceId.default(GROWINGIO_DATASOURCE_ID)
+            val serverHost = context.settingsDataStore.data.first().serverHost.default(GROWINGIO_SERVER_HOST)
+            configuration.setProject(projectId, urlScheme)
+                .setDataSourceId(dataSourceId)
+                .setDataCollectionServerHost(serverHost)
+        }
+    }
+
+    fun String.default(default: String): String {
+        if (this.isEmpty()) return default
+        return this
+    }
+
+    companion object {
+        const val GROWINGIO_PROJECT_ID = "0a1b4118dd954ec3bcc69da5138bdb96"
+        const val GROWINGIO_URL_SCHEME = "growing.bd71d91eb56f5f53"
+        const val GROWINGIO_DATASOURCE_ID = "baffd6fb52b78ca7"
+        const val GROWINGIO_SERVER_HOST = "https://napi.growingio.com"
     }
 
     override fun dependencies(): MutableList<Class<out Initializer<*>>> {

--- a/app/src/main/java/com/growingio/demo/navgraph/NavGraph.kt
+++ b/app/src/main/java/com/growingio/demo/navgraph/NavGraph.kt
@@ -57,6 +57,7 @@ internal sealed class PageNav(val root: FragmentNav, val path: String? = null, v
     object ComponentProtobufPage : PageNav(FragmentNav.DashBoard, "protobuf")
     object ComponentOaidPage : PageNav(FragmentNav.DashBoard, "oaid")
     object ComponentAdvertPage : PageNav(FragmentNav.DashBoard, "advert")
+    object ComponentWebServicePage : PageNav(FragmentNav.DashBoard, "webService")
 
     object MaterialRecyclerViewPage : PageNav(FragmentNav.UI, "recyclerview")
     object MaterialBottomAppBarPage : PageNav(FragmentNav.UI, "bottomappbar")

--- a/app/src/main/java/com/growingio/demo/ui/dashboard/ComponentWebServiceFragment.kt
+++ b/app/src/main/java/com/growingio/demo/ui/dashboard/ComponentWebServiceFragment.kt
@@ -1,0 +1,117 @@
+/*
+ *   Copyright (c) - 2023 Beijing Yishu Technology Co., Ltd.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.growingio.demo.ui.dashboard
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.result.ActivityResultLauncher
+import com.growingio.android.advert.AdvertConfig
+import com.growingio.android.advert.AdvertLibraryGioModule
+import com.growingio.android.sdk.autotrack.GrowingAutotracker
+import com.growingio.android.sdk.track.log.Logger
+import com.growingio.android.sdk.track.middleware.advert.Activate
+import com.growingio.android.sdk.track.middleware.advert.AdvertResult
+import com.growingio.android.sdk.track.middleware.advert.DeepLinkCallback
+import com.growingio.code.annotation.SourceCode
+import com.growingio.demo.R
+import com.growingio.demo.data.SdkIcon
+import com.growingio.demo.data.SdkIntroItem
+import com.growingio.demo.databinding.FragmentComponentAdvertBinding
+import com.growingio.demo.databinding.FragmentComponentWebserviceBinding
+import com.growingio.demo.navgraph.PageNav
+import com.growingio.demo.ui.base.PageFragment
+import com.growingio.demo.ui.camera.BarScanner
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import java.net.URLEncoder
+
+/**
+ * <p>
+ *
+ * @author cpacm 2023/4/20
+ */
+@AndroidEntryPoint
+class ComponentWebServiceFragment : PageFragment<FragmentComponentWebserviceBinding>() {
+
+    private lateinit var barScannerLauncher: ActivityResultLauncher<Void?>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        barScannerLauncher = registerForActivityResult(BarScanner(requireContext())) {
+            pageBinding.deeplink.editText?.setText(it)
+        }
+    }
+
+    override fun createPageBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentComponentWebserviceBinding {
+        return FragmentComponentWebserviceBinding.inflate(inflater, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setTitle(getString(R.string.component_webservice))
+
+        pageBinding.deeplink.setEndIconOnClickListener {
+            barScannerLauncher.launch(null)
+        }
+
+        pageBinding.goBtn.setOnClickListener {
+            val deeplinkUrl = pageBinding.deeplink.editText?.text
+            if (deeplinkUrl == null || deeplinkUrl.toString().isEmpty()) {
+                showMessage(R.string.component_webservice_toast)
+                return@setOnClickListener
+            }
+            val url = URLEncoder.encode(deeplinkUrl.toString())
+            findParentNavController()?.navigate(PageNav.WidgetAndroidH5Page.toUrl(url))
+        }
+
+        loadAssetCode(this)
+
+        // https://ads-uat.growingio.cn/k4budVa
+        setDefaultLogFilter("level:debug circle")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // reset default sdk state
+        barScannerLauncher.unregister()
+    }
+
+    @dagger.Module
+    @InstallIn(SingletonComponent::class)
+    object Module {
+        @IntoSet
+        @Provides
+        fun provideSdkItem(): SdkIntroItem {
+            return SdkIntroItem(
+                id = 25,
+                icon = SdkIcon.Component,
+                title = "圈选",
+                desc = "用于快速进入圈选或者数据校验状态，方便用户调试",
+                route = PageNav.ComponentWebServicePage.route(),
+                fragmentClass = ComponentWebServiceFragment::class,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/growingio/demo/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/growingio/demo/ui/dashboard/DashboardFragment.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.growingio.demo.data.SdkIntroItem
 import com.growingio.demo.databinding.FragmentDashboardBinding
 import com.growingio.demo.ui.base.ViewBindingFragment
+import com.growingio.demo.ui.home.HomeSettingFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -42,6 +43,11 @@ class DashboardFragment : ViewBindingFragment<FragmentDashboardBinding>() {
                 findParentNavController()?.navigate(item.route)
             }
         })
+
+        binding.accountIv.setOnClickListener {
+            HomeSettingFragment().show(childFragmentManager, "project_setting")
+        }
+
         viewModel.refreshData()
     }
 
@@ -60,6 +66,7 @@ class DashboardFragment : ViewBindingFragment<FragmentDashboardBinding>() {
                     is SdkItemState.SdkItemSet -> {
                         (binding.dashboardRv.adapter as DashboardAdapter).loadData(it.set)
                     }
+
                     else -> {}
                 }
             }

--- a/app/src/main/java/com/growingio/demo/ui/home/HomeSettingFragment.kt
+++ b/app/src/main/java/com/growingio/demo/ui/home/HomeSettingFragment.kt
@@ -1,0 +1,112 @@
+/*
+ *   Copyright (c) - 2023 Beijing Yishu Technology Co., Ltd.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.growingio.demo.ui.home
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.snackbar.Snackbar
+import com.growingio.android.sdk.TrackerContext
+import com.growingio.android.sdk.autotrack.GrowingAutotracker
+import com.growingio.demo.GrowingioInitializer
+import com.growingio.demo.R
+import com.growingio.demo.data.settingsDataStore
+import com.growingio.demo.databinding.FragmentProjectSettingBinding
+import kotlinx.coroutines.launch
+
+/**
+ * <p>
+ *
+ * @author cpacm 2023/9/14
+ */
+
+class HomeSettingFragment : BottomSheetDialogFragment() {
+
+    private var _binding: FragmentProjectSettingBinding? = null
+    val binding get() = _binding!!
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = FragmentProjectSettingBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        if (TrackerContext.initializedSuccessfully()) {
+            val configuration = GrowingAutotracker.get().context.configurationProvider
+            val projectId = configuration.core().projectId
+            val urlScheme = configuration.core().urlScheme
+            val dataSourceId = configuration.core().dataSourceId
+            val serverHost = configuration.core().dataCollectionServerHost
+
+            binding.pidEt.setText(projectId)
+            binding.urlEt.setText(urlScheme)
+            binding.dataEt.setText(dataSourceId)
+            binding.hostEt.setText(serverHost)
+        }
+
+        binding.settle.setOnClickListener {
+            val pid = binding.pidEt.text.toString()
+            val url = binding.urlEt.text.toString()
+            val data = binding.dataEt.text.toString()
+            val host = binding.hostEt.text.toString()
+
+            if (!TrackerContext.initializedSuccessfully()) {
+                dismiss()
+                return@setOnClickListener
+            }
+
+            if (pid.isEmpty() || url.isEmpty() || data.isEmpty() || host.isEmpty()) {
+                Snackbar.make(view, R.string.setting_settle_hint, Snackbar.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            val configuration = GrowingAutotracker.get().context.configurationProvider.core();
+            if (pid == configuration.projectId && data == configuration.dataSourceId && host == configuration.dataCollectionServerHost) {
+                Snackbar.make(view, R.string.setting_settle_hint2, Snackbar.LENGTH_SHORT).show()
+                dismiss()
+                return@setOnClickListener
+            }
+
+
+            lifecycleScope.launch {
+
+                GrowingAutotracker.shutdown()
+                requireContext().settingsDataStore.updateData {
+                    it.toBuilder().setProjectId(pid)
+                        .setUrlScheme(url)
+                        .setDatasourceId(data)
+                        .setServerHost(host)
+                        .build()
+                }
+
+                val sdkInitialize = GrowingioInitializer()
+                sdkInitialize.create(requireActivity())
+                dismiss()
+            }
+
+        }
+    }
+}

--- a/app/src/main/java/com/growingio/demo/ui/webview/SdkH5WebView.kt
+++ b/app/src/main/java/com/growingio/demo/ui/webview/SdkH5WebView.kt
@@ -18,6 +18,7 @@
 package com.growingio.demo.ui.webview
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -28,6 +29,9 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.growingio.android.sdk.autotrack.GrowingAutotracker
+import com.growingio.android.sdk.track.listener.event.ActivityLifecycleEvent
+import com.growingio.android.sdk.track.providers.DeepLinkProvider
 
 @SuppressLint("SetJavaScriptEnabled")
 class SdkH5WebView : WebView {
@@ -68,7 +72,16 @@ class SdkH5WebView : WebView {
 
     private inner class BaseWebClient : WebViewClient() {
 
-        override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest?): Boolean {
+            if (request?.url?.scheme?.startsWith("growing.") == true) {
+                val deepLinkProvider =
+                    GrowingAutotracker.get().context.getProvider<DeepLinkProvider>(DeepLinkProvider::class.java)
+                val activity = view.context as? Activity
+                val intent = Intent.parseUri(request.url.toString(), Intent.URI_ALLOW_UNSAFE)
+                val event = ActivityLifecycleEvent.createOnNewIntentEvent(activity, intent)
+                deepLinkProvider.onActivityLifecycle(event)
+                return true
+            }
             return super.shouldOverrideUrlLoading(view, request)
         }
 

--- a/app/src/main/proto/settings.proto
+++ b/app/src/main/proto/settings.proto
@@ -7,6 +7,11 @@ option java_multiple_files = true;
 message Settings {
   bool agree_policy = 1;
 
+  string project_id = 2;
+  string datasource_id = 3;
+  string url_scheme = 4;
+  string server_host = 5;
+
   //int64 timestamp = 8;
   //int32 event_sequence_id = 15;
   //map<string, string> extra_sdk = 21;//VisitEvent

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12 19,6.41z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_component_webservice.xml
+++ b/app/src/main/res/layout/fragment_component_webservice.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/sdkHint"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/component_webservice_hint"
+        android:textAppearance="@style/TextAppearance.Material3.LabelSmall"
+        android:textColor="?attr/colorTextGray"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/deeplink"
+        style="?attr/textInputOutlinedStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="24dp"
+        android:hint="@string/component_webservice_et_hint"
+        app:endIconContentDescription="@string/component_webservice_et_hint"
+        app:endIconDrawable="@drawable/ic_scanner"
+        app:endIconMode="custom"
+        app:helperText="@string/component_webservice_helper"
+        app:helperTextEnabled="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/sdkHint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+
+    <Button
+        android:id="@+id/goBtn"
+        style="@style/Widget.Material3.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="@string/material_webview_go"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/deeplink" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_project_setting.xml
+++ b/app/src/main/res/layout/fragment_project_setting.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.bottomsheet.BottomSheetDragHandleView
+        android:id="@+id/handleView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/sdkHint"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/setting_project_hint"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+        app:layout_constraintTop_toBottomOf="@id/handleView"
+        app:layout_constraintEnd_toEndOf="parent"
+
+        app:layout_constraintStart_toStartOf="parent" />
+
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/projectId"
+        style="?attr/textInputOutlinedDenseStyle"
+        android:layout_width="@dimen/material_textinput_default_width"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:hint="@string/setting_project_id"
+        app:helperText="@string/setting_project_id_hint"
+        app:helperTextEnabled="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/sdkHint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/pidEt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/urlScheme"
+        style="?attr/textInputOutlinedDenseStyle"
+        android:layout_width="@dimen/material_textinput_default_width"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="12dp"
+        android:hint="@string/setting_url_scheme"
+        app:helperText="@string/setting_url_scheme_hint"
+        app:helperTextEnabled="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/projectId">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/urlEt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/dataSourceId"
+        style="?attr/textInputOutlinedDenseStyle"
+        android:layout_width="@dimen/material_textinput_default_width"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="12dp"
+        android:hint="@string/setting_data_source_id"
+        app:helperText="@string/setting_data_source_id_hint"
+        app:helperTextEnabled="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/urlScheme">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/dataEt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/serverHost"
+        style="?attr/textInputOutlinedDenseStyle"
+        android:layout_width="@dimen/material_textinput_default_width"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="12dp"
+        android:hint="@string/setting_server_host"
+        app:helperText="@string/setting_server_host_hint"
+        app:helperTextEnabled="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/dataSourceId">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/hostEt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <Button
+        android:id="@+id/settle"
+        style="@style/Widget.Material3.Button.OutlinedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/setting_sdk_btn"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/serverHost" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,20 @@
     <string name="dashboard_page_intro">INTRO</string>
     <string name="dashboard_page_code">CODE</string>
 
+    <string name="setting_project_hint">设置SDK的项目ID</string>
+    <string name="setting_project_id">ProjectId</string>
+    <string name="setting_project_id_hint">项目的AccountId</string>
+    <string name="setting_url_scheme">URLScheme</string>
+    <string name="setting_url_scheme_hint">用于唤醒App</string>
+    <string name="setting_url_scheme_hint2">重新设置后，请在该App内进入圈选服务</string>
+    <string name="setting_data_source_id">DataSourceId</string>
+    <string name="setting_data_source_id_hint">数据源 ID</string>
+    <string name="setting_server_host">收数地址</string>
+    <string name="setting_server_host_hint">用于接收数据的服务器地址</string>
+    <string name="setting_sdk_btn">设置</string>
+    <string name="setting_settle_hint">请设置正确的配置</string>
+    <string name="setting_settle_hint2">SDK 配置未做改变！</string>
+
     <string name="sdk_log_hint">可以打开右下角的 Logcat 查看SDK的运行日志。</string>
     <string name="sdk_init_title">初始化</string>
     <string name="sdk_autotrack_option">无埋点配置</string>
@@ -139,6 +153,11 @@
     <string name="component_advert_generate">默认链接</string>
     <string name="component_advert_default_url">https://ads-uat.growingio.cn/k4budVa</string>
     <string name="component_advert_parse">解析链接</string>
+    <string name="component_webservice">圈选服务</string>
+    <string name="component_webservice_hint">用于启动圈选或者数据校验服务</string>
+    <string name="component_webservice_toast">请扫描二维码获取链接</string>
+    <string name="component_webservice_et_hint">扫描二维码连接电脑与移动应用</string>
+    <string name="component_webservice_helper">访问链接启动服务</string>
 
     <string name="material_test_btn">测试</string>
     <string name="material_button">Material Button</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ markwon = "4.6.2"
 
 # growingio
 growingio = "4.0.0"
-growingioPlugin = "3.5.0"
+growingioPlugin = "4.0.0"
 giokit = "2.0.0"
 
 pluginGradle = "8.1.0" #"7.4.2"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,7 @@
 pluginManagement {
     repositories {
         google()
-        mavenCentral()
         mavenLocal()
-        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
1. 添加圈选页面，可以在App内部直接唤醒圈选服务；
2. 添加SDK配置页面，可以在运行中更改sdk的projectid,datasourceId,urlScheme和serverHost;

> tip:由于无法更改唤醒app的urlScheme配置，所以修改配置后的圈选需要使用功能1唤醒。